### PR TITLE
fix: remove ENTRYPOINT from cuda-conda Dockerfile

### DIFF
--- a/cuda-conda/Dockerfile
+++ b/cuda-conda/Dockerfile
@@ -64,5 +64,3 @@ EXPOSE 8888
 ENV CONDA_DEFAULT_ENV=ml
 ENV CONDA_PREFIX=${CONDA_DIR}/envs/ml
 
-# Start JupyterLab with conda environment
-ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "ml", "jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]

--- a/cuda-conda/README.md
+++ b/cuda-conda/README.md
@@ -10,8 +10,20 @@ This repository contains a Dockerfile for building a CUDA-enabled Conda environm
 
 ## Usage
 
+### Interactive Shell
 ```bash
-docker run -v workspace:/workspace -p 10000:8888 --rm --gpus all ghcr.io/akriaueno/cuda-conda:11.8.0-ubuntu22.04-python3.9
+# Start an interactive bash session
+docker run -it --rm --gpus all ghcr.io/akriaueno/cuda-conda:11.8.0-ubuntu22.04-python3.9
+
+# Inside the container, activate conda environment
+conda activate ml
+```
+
+### JupyterLab
+```bash
+# Start JupyterLab server
+docker run -v $(pwd):/workspace -p 10000:8888 --rm --gpus all ghcr.io/akriaueno/cuda-conda:11.8.0-ubuntu22.04-python3.9 \
+    conda run -n ml jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root
 ```
 
 Go to http://localhost:10000 and enter the token shown in the terminal.
@@ -50,7 +62,6 @@ https://hub.docker.com/r/nvidia/cuda
 ## Conda Environment
 
 The Docker image includes Miniconda3 with a dedicated conda environment named `ml`.
-This environment is automatically activated when the container starts.
 
 ## Image Tag
 

--- a/tests/test_cuda_conda.py
+++ b/tests/test_cuda_conda.py
@@ -104,7 +104,7 @@ class TestCudaCondaBuild:
         # Verify the image runs (basic test)
         verify_result = subprocess.run([
             "docker", "run", "--rm", "--platform", "linux/amd64", 
-            "--entrypoint", "/opt/conda/envs/ml/bin/python", tag, 
+            tag, "/opt/conda/envs/ml/bin/python", 
             "-c", "print('Container is working')"
         ], capture_output=True, text=True, timeout=30)
         
@@ -114,7 +114,7 @@ class TestCudaCondaBuild:
         # Verify Python version
         python_check = subprocess.run([
             "docker", "run", "--rm", "--platform", "linux/amd64",
-            "--entrypoint", "/opt/conda/envs/ml/bin/python", tag,
+            tag, "/opt/conda/envs/ml/bin/python",
             "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
         ], capture_output=True, text=True, timeout=30)
         
@@ -124,7 +124,7 @@ class TestCudaCondaBuild:
         # Verify CUDA version
         cuda_check = subprocess.run([
             "docker", "run", "--rm", "--platform", "linux/amd64",
-            "--entrypoint", "bash", tag,
+            tag, "bash",
             "-c", "nvcc --version | grep 'release' | sed 's/.*release //' | sed 's/,.*//'"
         ], capture_output=True, text=True, timeout=30)
         
@@ -136,7 +136,7 @@ class TestCudaCondaBuild:
         # Verify conda is working
         conda_check = subprocess.run([
             "docker", "run", "--rm", "--platform", "linux/amd64",
-            "--entrypoint", "bash", tag,
+            tag, "bash",
             "-c", "source /opt/conda/etc/profile.d/conda.sh && conda activate ml && conda --version"
         ], capture_output=True, text=True, timeout=30)
         
@@ -146,7 +146,7 @@ class TestCudaCondaBuild:
         # Verify conda can install packages
         conda_install_check = subprocess.run([
             "docker", "run", "--rm", "--platform", "linux/amd64",
-            "--entrypoint", "bash", tag,
+            tag, "bash",
             "-c", "source /opt/conda/etc/profile.d/conda.sh && conda activate ml && conda install -y numpy --override-channels -c conda-forge && python -c 'import numpy; print(f\"NumPy {numpy.__version__} installed\")'"
         ], capture_output=True, text=True, timeout=120)
         
@@ -183,7 +183,7 @@ def test_minimal_cuda_conda_build(project_root, docker_build_timeout, cleanup_do
     # Verify the image runs
     verify_result = subprocess.run([
         "docker", "run", "--rm", "--platform", "linux/amd64",
-        "--entrypoint", "/opt/conda/envs/ml/bin/python", tag,
+        tag, "/opt/conda/envs/ml/bin/python",
         "-c", "print('Minimal test passed')"
     ], capture_output=True, text=True, timeout=30)
     
@@ -192,7 +192,7 @@ def test_minimal_cuda_conda_build(project_root, docker_build_timeout, cleanup_do
     # Verify Python version for minimal build
     python_check = subprocess.run([
         "docker", "run", "--rm", "--platform", "linux/amd64",
-        "--entrypoint", "/opt/conda/envs/ml/bin/python", tag,
+        tag, "/opt/conda/envs/ml/bin/python",
         "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
     ], capture_output=True, text=True, timeout=30)
     


### PR DESCRIPTION
## Summary
- Remove ENTRYPOINT from cuda-conda Dockerfile for more flexible container usage
- Update README with separate instructions for shell and JupyterLab usage
- Update tests to work without ENTRYPOINT overrides

## Test plan
- [x] All tests pass without --entrypoint overrides
- [x] Container can be used as interactive shell by default
- [x] JupyterLab can be started with explicit command

🤖 Generated with [Claude Code](https://claude.ai/code)