### PR TITLE
fix: add conda init to properly initialize conda in containers

### DIFF
--- a/cuda-conda/Dockerfile
+++ b/cuda-conda/Dockerfile
@@ -35,14 +35,19 @@ RUN ${CONDA_DIR}/bin/conda config --remove channels defaults || true && \
     ${CONDA_DIR}/bin/conda config --add channels conda-forge && \
     ${CONDA_DIR}/bin/conda config --set channel_priority strict
 
+# Initialize conda for bash shell
+RUN ${CONDA_DIR}/bin/conda init bash
+
 # Create conda environment with specified Python version
 # Retry logic for conda operations to handle intermittent network issues
 RUN for i in 1 2 3; do \
         ${CONDA_DIR}/bin/conda create -n ml python=${PYTHON_VERSION} -y --override-channels --channel conda-forge && \
-        echo "conda activate ml" >> ~/.bashrc && \
         break || \
         (echo "Retry $i failed, waiting..." && sleep 10); \
     done
+
+# Add conda activate to bashrc after conda init
+RUN echo "conda activate ml" >> ~/.bashrc
 
 # Install JupyterLab in the conda environment
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
## Summary
- Add 'conda init bash' during image build to fix "CondaError: Run 'conda init' before 'conda activate'" error
- Separate conda environment creation from bashrc modification
- Ensures 'conda activate ml' works immediately when users start interactive shells

## Problem
When running containers with the current image, users encounter:
```
CondaError: Run 'conda init' before 'conda activate'
```

## Solution
Added `conda init bash` during the build process, which properly initializes conda for bash shells. This allows the `conda activate ml` command in .bashrc to work correctly.

## Test plan
- [ ] Build the image with the updated Dockerfile
- [ ] Run `docker run -it <image>` and verify ml environment is automatically activated
- [ ] Verify no conda errors appear on container startup

🤖 Generated with [Claude Code](https://claude.ai/code)